### PR TITLE
Fix destructive double alias

### DIFF
--- a/config/aliases.example.yml
+++ b/config/aliases.example.yml
@@ -15,11 +15,11 @@ discrim:
 changediscrim:
   - cd
 createtag:
-  - ct
+  - crt
 deletetag:
   - dt
 cleartags:
-  - ct
+  - clt
 tag:
   - t
 youtube:


### PR DESCRIPTION
Cleartags and createtag had the same alias of ct. Maybe you shouldn't make people wipe their tag DB's, just saying ;)